### PR TITLE
Fix classroom title alignment

### DIFF
--- a/client/src/components/Medical.js
+++ b/client/src/components/Medical.js
@@ -3,7 +3,7 @@ import { PlantCell, AnimalCell, Skeleton } from "./3DModel";
 const Medical = () => {
   return (
     <div>
-      <div className="text-3xl text-white font-extralight ml-48 mt-8">
+      <div className="text-3xl text-white font-extralight text-center mt-8">
         Medical
       </div>
       <PlantCell />

--- a/client/src/components/Planets.js
+++ b/client/src/components/Planets.js
@@ -3,7 +3,7 @@ import { Planet, PlanetMars, PlanetJupiter } from "./3DModel";
 const Planets = () => {
   return (
     <div>
-      <div className="text-3xl text-white font-extralight ml-48 mt-8">
+      <div className="text-3xl text-white font-extralight text-center mt-8">
         Planets
       </div>
       <Planet />


### PR DESCRIPTION
# Description

Classroom titles' position has been unified to the center.

Fixes # (issue no.) 
Fix classroom title alignment #124 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (Maybe changes for the screenshots are needed)

# Explain the Testing instructions

**Test Configuration**:
* Operating system: MacOS Darwin arm64 23.0.0
* Version: Node.js: 18.15.0
* Text-editors used: VScode Version: 1.83.1 (Universal)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

# ATTACH SCREENSHOTS
<img width="1300" alt="Screenshot 2023-10-23 at 7 52 03 am" src="https://github.com/gauravsinhaweb/EduSmart/assets/112826656/b00f2a50-3596-431c-97e9-438b904e239a">
<img width="1295" alt="Screenshot 2023-10-23 at 7 51 55 am" src="https://github.com/gauravsinhaweb/EduSmart/assets/112826656/34206b68-ca04-4698-b825-c73638894f89">
<img width="1348" alt="Screenshot 2023-10-23 at 7 51 49 am" src="https://github.com/gauravsinhaweb/EduSmart/assets/112826656/d6dedaf3-ec65-47c7-a668-d526e173abf3">
